### PR TITLE
fix: allow use of: set -u in parent script

### DIFF
--- a/bash-cache.sh
+++ b/bash-cache.sh
@@ -129,7 +129,7 @@ bc::_read_input() {
      _contents+=("$_line"$'\n')
    done
    # include $_line once more to capture any content after the last newline
-   printf -v "$1" '%s' "${_contents[@]+"${_contents[@]}"}" "$_line"
+   printf -v "$1" '%s' ${_contents[@]+"${_contents[@]}"} "$_line"
 }
 
 # Given a name and an existing function, create a new function called name that
@@ -153,7 +153,7 @@ bc::off() { _bc_enabled=false; }
 # Assumes ${env[@]}, ${func}, and ${args[@]} are set appropriately
 bc::_set_cache_read_loc() {
   # NOT local; must be local in calling function
-  cache_read_loc="${_bc_cache_dir}/$(bc::_hash "${env[@]+"${env[@]}"}" -- "$func" "${args[@]+"${args[@]}"}")"
+  cache_read_loc="${_bc_cache_dir}/$(bc::_hash ${env[@]+"${env[@]}"} -- "$func" ${args[@]+"${args[@]}"})"
 }
 
 # Captures function output and writes to disc
@@ -162,7 +162,7 @@ bc::_write_cache() {
   local cache_write_dir="${_bc_cache_dir}/data/${ttl}" cache
   bc::_ensure_dir_exists "$cache_write_dir"
   cache=$(mktemp -d "${cache_write_dir}/XXXXXXXXXX") || return
-  "bc::orig::${func}" "${args[@]+"${args[@]}"}" > "${cache}/out" 2> "${cache}/err"
+  "bc::orig::${func}" ${args[@]+"${args[@]}"} > "${cache}/out" 2> "${cache}/err"
   printf '%s' $? > "${cache}/exit"
   ln -sfn "$cache" "$cache_read_loc" # atomic
 }
@@ -343,7 +343,7 @@ bc::cache() {
       -e "s/%func%/${func}/g" \
       -e "s/%ttl%/${ttl}/g" \
       -e "s/%refresh%/${refresh}/g" \
-      -e "s/%env%/${env[*]+"${env[*]}"}/g")"
+      -e "s/%env%/${env[*]:-}/g")"
 }
 
 # Further decorates bc::cache with a mutual-exclusion lock. This ensures that
@@ -461,7 +461,7 @@ bc::memoize() {
 
     for (( v=1; v<=$#; v++ )); do vars+=("$v"); done
     vars+=(%env%)
-    for v in "${vars[@]+"${vars[@]}"}"; do
+    for v in ${vars[@]+"${vars[@]}"}; do
       # shellcheck disable=SC2016
       printf -v check '&& [[ "${%q:-}" == %q ]]' "$v" "${!v:-}"
       checks+=("$check")
@@ -471,7 +471,7 @@ bc::memoize() {
     printf -v func '%q() {
     "$_bc_enabled" || { bc::orig::%q "$@"; return; }
     if (( $# == %q )) %s; then printf "%%s" %q; else bc::memoize::%q "$@"; fi; }' \
-     '%func%' '%func%' "$#" "${checks[*]+"${checks[*]}"}" "$output" '%func%'
+     '%func%' '%func%' "$#" "${checks[*]:-}" "$output" '%func%'
     eval "$func"
   }
 
@@ -482,7 +482,7 @@ bc::memoize() {
     "$func" "$func" "$func" "$memoize_function_body" \
     | sed \
       -e "s/%func%/${func}/g" \
-      -e "s/%env%/${env[*]+"${env[*]}"}/g")"
+      -e "s/%env%/${env[*]:-}/g")"
 }
 
 # Prints the real-time to execute the given command, discarding its output.

--- a/bash-cache.sh
+++ b/bash-cache.sh
@@ -129,7 +129,7 @@ bc::_read_input() {
      _contents+=("$_line"$'\n')
    done
    # include $_line once more to capture any content after the last newline
-   printf -v "$1" '%s' "${_contents[@]}" "$_line"
+   printf -v "$1" '%s' "${_contents[@]+"${_contents[@]}"}" "$_line"
 }
 
 # Given a name and an existing function, create a new function called name that
@@ -153,7 +153,7 @@ bc::off() { _bc_enabled=false; }
 # Assumes ${env[@]}, ${func}, and ${args[@]} are set appropriately
 bc::_set_cache_read_loc() {
   # NOT local; must be local in calling function
-  cache_read_loc="${_bc_cache_dir}/$(bc::_hash "${env[@]}" -- "$func" "${args[@]}")"
+  cache_read_loc="${_bc_cache_dir}/$(bc::_hash "${env[@]+"${env[@]}"}" -- "$func" "${args[@]+"${args[@]}"}")"
 }
 
 # Captures function output and writes to disc
@@ -162,7 +162,7 @@ bc::_write_cache() {
   local cache_write_dir="${_bc_cache_dir}/data/${ttl}" cache
   bc::_ensure_dir_exists "$cache_write_dir"
   cache=$(mktemp -d "${cache_write_dir}/XXXXXXXXXX") || return
-  "bc::orig::${func}" "${args[@]}" > "${cache}/out" 2> "${cache}/err"
+  "bc::orig::${func}" "${args[@]+"${args[@]}"}" > "${cache}/out" 2> "${cache}/err"
   printf '%s' $? > "${cache}/exit"
   ln -sfn "$cache" "$cache_read_loc" # atomic
 }
@@ -343,7 +343,7 @@ bc::cache() {
       -e "s/%func%/${func}/g" \
       -e "s/%ttl%/${ttl}/g" \
       -e "s/%refresh%/${refresh}/g" \
-      -e "s/%env%/${env[*]}/g")"
+      -e "s/%env%/${env[*]+"${env[*]}"}/g")"
 }
 
 # Further decorates bc::cache with a mutual-exclusion lock. This ensures that
@@ -461,7 +461,7 @@ bc::memoize() {
 
     for (( v=1; v<=$#; v++ )); do vars+=("$v"); done
     vars+=(%env%)
-    for v in "${vars[@]}"; do
+    for v in "${vars[@]+"${vars[@]}"}"; do
       # shellcheck disable=SC2016
       printf -v check '&& [[ "${%q:-}" == %q ]]' "$v" "${!v:-}"
       checks+=("$check")
@@ -471,7 +471,7 @@ bc::memoize() {
     printf -v func '%q() {
     "$_bc_enabled" || { bc::orig::%q "$@"; return; }
     if (( $# == %q )) %s; then printf "%%s" %q; else bc::memoize::%q "$@"; fi; }' \
-     '%func%' '%func%' "$#" "${checks[*]}" "$output" '%func%'
+     '%func%' '%func%' "$#" "${checks[*]+"${checks[*]}"}" "$output" '%func%'
     eval "$func"
   }
 
@@ -482,7 +482,7 @@ bc::memoize() {
     "$func" "$func" "$func" "$memoize_function_body" \
     | sed \
       -e "s/%func%/${func}/g" \
-      -e "s/%env%/${env[*]}/g")"
+      -e "s/%env%/${env[*]+"${env[*]}"}/g")"
 }
 
 # Prints the real-time to execute the given command, discarding its output.

--- a/bash-cache.sh
+++ b/bash-cache.sh
@@ -9,7 +9,7 @@
 _bc_enabled=true
 _bc_version=(0 10 0)
 
-if [[ -n "$BC_HASH_COMMAND" ]]; then
+if [[ -n "${BC_HASH_COMMAND:-}" ]]; then
   _bc_hash_command="$BC_HASH_COMMAND"
 elif command -v sha1sum &> /dev/null; then
   _bc_hash_command='sha1sum'
@@ -17,7 +17,7 @@ elif command -v shasum &> /dev/null; then # OSX
   _bc_hash_command='shasum'
 fi
 
-if [[ -n "$_BC_TESTONLY_CACHE_DIR" ]]; then
+if [[ -n "${_BC_TESTONLY_CACHE_DIR:-}" ]]; then
   _bc_cache_dir="$_BC_TESTONLY_CACHE_DIR"
 else
   printf -v _bc_cache_dir '%s/bash-cache-%s.%s-%s' \
@@ -231,12 +231,12 @@ bc::_do_cleanup() {
 bc::cache() {
   local _seconds func="${1:?"Must provide a function name to cache"}"; shift
   local ttl=60 # legacy support for a default TTL duration, may go away
-  if [[ "$1" =~ [0-9]+[dhms]$ ]]; then # safe because variable names can't match this pattern
+  if [[ "${1:-}" =~ [0-9]+[dhms]$ ]]; then # safe because variable names can't match this pattern
     bc::_to_seconds "$1" || return; shift
     ttl=$_seconds
   fi
   local refresh=10 # legacy support for a default refresh duration, may go away
-  if [[ "$1" =~ [0-9]+[dhms]$ ]]; then # safe because variable names can't match this pattern
+  if [[ "${1:-}" =~ [0-9]+[dhms]$ ]]; then # safe because variable names can't match this pattern
     bc::_to_seconds "$1" || return; shift
     refresh=$_seconds
   fi
@@ -258,7 +258,7 @@ bc::cache() {
   local v escaped env=()
   for v in "$@"; do
     # shellcheck disable=SC2016
-    printf -v escaped '"${%s}"' "$v"
+    printf -v escaped '"${%s:-}"' "$v"
     if ! eval ": ${escaped}" 2>/dev/null; then
       echo "${v} is not a valid variable" >&2
       return 1
@@ -439,7 +439,7 @@ bc::memoize() {
   local v escaped env=()
   for v in "$@"; do
     # shellcheck disable=SC2016
-    printf -v escaped '"${%s}"' "$v"
+    printf -v escaped '"${%s:-}"' "$v"
     if ! eval ": ${escaped}" 2>/dev/null; then
       echo "${v} is not a valid variable" >&2
       return 1
@@ -463,7 +463,7 @@ bc::memoize() {
     vars+=(%env%)
     for v in "${vars[@]}"; do
       # shellcheck disable=SC2016
-      printf -v check '&& [[ "${%q}" == %q ]]' "$v" "${!v}"
+      printf -v check '&& [[ "${%q:-}" == %q ]]' "$v" "${!v:-}"
       checks+=("$check")
     done
 

--- a/test/bash-cache.bats
+++ b/test/bash-cache.bats
@@ -5,8 +5,7 @@
 # Note most of these tests assumes the test takes less than 10 seconds (the background-refresh time)
 # ideally we could configure the stale cache threshold for the test so this is less brittle.
 
-# Treat unset variables  as an error
-set -u
+set -u  # Treat unset variables as an error
 
 # Ensure each test has its own cache
 TEST_DIR=$(mktemp -d "${BATS_TMPDIR}/bash-cache-XXXXXXXXXX")

--- a/test/bash-cache.bats
+++ b/test/bash-cache.bats
@@ -5,6 +5,9 @@
 # Note most of these tests assumes the test takes less than 10 seconds (the background-refresh time)
 # ideally we could configure the stale cache threshold for the test so this is less brittle.
 
+# Treat unset variables  as an error
+set -u
+
 # Ensure each test has its own cache
 TEST_DIR=$(mktemp -d "${BATS_TMPDIR}/bash-cache-XXXXXXXXXX")
 _BC_TESTONLY_CACHE_DIR="${TEST_DIR}/cache"

--- a/test/bc-unit-tests.bats
+++ b/test/bc-unit-tests.bats
@@ -2,8 +2,7 @@
 #
 # Unit tests of individual bash-cache functions, not overall caching semantics.
 
-# Treat unset variables  as an error
-set -u
+set -u  # Treat unset variables as an error
 
 source "${BATS_TEST_DIRNAME}/../bash-cache.sh"
 

--- a/test/bc-unit-tests.bats
+++ b/test/bc-unit-tests.bats
@@ -2,6 +2,9 @@
 #
 # Unit tests of individual bash-cache functions, not overall caching semantics.
 
+# Treat unset variables  as an error
+set -u
+
 source "${BATS_TEST_DIRNAME}/../bash-cache.sh"
 
 skip_osx() {


### PR DESCRIPTION
I've found that if my script has `set -u` defined before importing this library, it break with such errors:
```
line 11: BC_HASH_COMMAND: unbound variable
```
here is a fix.

Also fixed a typo and `bc::locked_cache` function name in the README.